### PR TITLE
use SHA256 tags for Oracle Linux images

### DIFF
--- a/verrazzano/filebeat/Dockerfile
+++ b/verrazzano/filebeat/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (C) 2020, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
-FROM container-registry.oracle.com/os/oraclelinux:7.8 as build_base
+FROM container-registry.oracle.com/os/oraclelinux:7.8@sha256:46fc083cf0250ed5260fa6fe822d7d4c139ca1f7fc38e4a17ba662464bd1df4a as build_base
 
 ARG VERSION
 
@@ -29,7 +29,7 @@ COPY . .
 WORKDIR /go/src/github.com/elastic/beats/filebeat
 RUN make
 
-FROM container-registry.oracle.com/os/oraclelinux:7-slim
+FROM container-registry.oracle.com/os/oraclelinux:7-slim@sha256:9b86d1332a883ee8f68dd44ba42133de518b2e0ec1cc70257e59fb4da86b1ad3
 
 WORKDIR /usr/share/filebeat
 COPY --from=build_base /go/src/github.com/elastic/beats/filebeat/filebeat .

--- a/verrazzano/journalbeat/Dockerfile
+++ b/verrazzano/journalbeat/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (C) 2020, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
-FROM container-registry.oracle.com/os/oraclelinux:7.8 as build_base
+FROM container-registry.oracle.com/os/oraclelinux:7.8@sha256:46fc083cf0250ed5260fa6fe822d7d4c139ca1f7fc38e4a17ba662464bd1df4a as build_base
 
 ARG VERSION
 
@@ -29,7 +29,7 @@ COPY . .
 WORKDIR /go/src/github.com/elastic/beats/journalbeat
 RUN make
 
-FROM container-registry.oracle.com/os/oraclelinux:7-slim
+FROM container-registry.oracle.com/os/oraclelinux:7-slim@sha256:9b86d1332a883ee8f68dd44ba42133de518b2e0ec1cc70257e59fb4da86b1ad3
 
 # journalbeat uses go-systemd which uses wrapper around c libs for journald/systemd
 RUN yum install -y systemd-devel system-libs && yum clean all && rm -rf /var/cache/yum


### PR DESCRIPTION
use SHA256 tags for Oracle Linux images

Acceptance test using this image: https://build.verrazzano.io/job/verrazzano/job/pmackin-images-2-external-dns-etc/13/