### PR TITLE
Update the build of filebeats and journalbeats to use Go 1.14.4

### DIFF
--- a/verrazzano/filebeat/Dockerfile
+++ b/verrazzano/filebeat/Dockerfile
@@ -10,7 +10,7 @@ RUN yum update -y \
     && yum-config-manager --save --setopt=ol7_ociyum_config.skip_if_unavailable=true \
     && yum install -y oracle-golang-release-el7 \
     && yum-config-manager --add-repo http://yum.oracle.com/repo/OracleLinux/OL7/developer/golang114/x86_64 \
-    && yum install -y git gcc make golang-1.14.3-1.el7 \
+    && yum install -y git gcc make golang-1.14.4-1.el7 \
     && yum clean all \
     && go version
 

--- a/verrazzano/filebeat/Dockerfile
+++ b/verrazzano/filebeat/Dockerfile
@@ -9,7 +9,6 @@ ARG VERSION
 RUN yum update -y \
     && yum-config-manager --save --setopt=ol7_ociyum_config.skip_if_unavailable=true \
     && yum install -y oracle-golang-release-el7 \
-    && yum-config-manager --enable ol7_developer_golang113 \
     && yum-config-manager --add-repo http://yum.oracle.com/repo/OracleLinux/OL7/developer/golang114/x86_64 \
     && yum install -y git gcc make golang-1.14.3-1.el7 \
     && yum clean all \

--- a/verrazzano/filebeat/Dockerfile
+++ b/verrazzano/filebeat/Dockerfile
@@ -10,8 +10,8 @@ RUN yum update -y \
     && yum-config-manager --save --setopt=ol7_ociyum_config.skip_if_unavailable=true \
     && yum install -y oracle-golang-release-el7 \
     && yum-config-manager --enable ol7_developer_golang113 \
-    && yum-config-manager --add-repo http://yum.oracle.com/repo/OracleLinux/OL7/developer/golang113/x86_64 \
-    && yum install -y git gcc make golang-1.13.3-1.el7.x86_64 \
+    && yum-config-manager --add-repo http://yum.oracle.com/repo/OracleLinux/OL7/developer/golang114/x86_64 \
+    && yum install -y git gcc make golang-1.14.3-1.el7 \
     && yum clean all \
     && go version
 

--- a/verrazzano/journalbeat/Dockerfile
+++ b/verrazzano/journalbeat/Dockerfile
@@ -10,7 +10,7 @@ RUN yum update -y \
     && yum-config-manager --save --setopt=ol7_ociyum_config.skip_if_unavailable=true \
     && yum install -y oracle-golang-release-el7 \
     && yum-config-manager --add-repo http://yum.oracle.com/repo/OracleLinux/OL7/developer/golang114/x86_64 \
-    && yum install -y git gcc make golang-1.14.3-1.el7 \
+    && yum install -y git gcc make golang-1.14.4-1.el7 \
     && yum clean all \
     && go version
 

--- a/verrazzano/journalbeat/Dockerfile
+++ b/verrazzano/journalbeat/Dockerfile
@@ -9,7 +9,6 @@ ARG VERSION
 RUN yum update -y \
     && yum-config-manager --save --setopt=ol7_ociyum_config.skip_if_unavailable=true \
     && yum install -y oracle-golang-release-el7 \
-    && yum-config-manager --enable ol7_developer_golang113 \
     && yum-config-manager --add-repo http://yum.oracle.com/repo/OracleLinux/OL7/developer/golang114/x86_64 \
     && yum install -y git gcc make golang-1.14.3-1.el7 \
     && yum clean all \

--- a/verrazzano/journalbeat/Dockerfile
+++ b/verrazzano/journalbeat/Dockerfile
@@ -10,8 +10,8 @@ RUN yum update -y \
     && yum-config-manager --save --setopt=ol7_ociyum_config.skip_if_unavailable=true \
     && yum install -y oracle-golang-release-el7 \
     && yum-config-manager --enable ol7_developer_golang113 \
-    && yum-config-manager --add-repo http://yum.oracle.com/repo/OracleLinux/OL7/developer/golang113/x86_64 \
-    && yum install -y git gcc make golang-1.13.3-1.el7.x86_64 \
+    && yum-config-manager --add-repo http://yum.oracle.com/repo/OracleLinux/OL7/developer/golang114/x86_64 \
+    && yum install -y git gcc make golang-1.14.3-1.el7 \
     && yum clean all \
     && go version
 

--- a/verrazzano/journalbeat/Dockerfile
+++ b/verrazzano/journalbeat/Dockerfile
@@ -15,6 +15,7 @@ RUN yum update -y \
     && yum clean all \
     && go version
 
+
 # Compile to /usr/bin
 ENV GOBIN=/usr/bin
 


### PR DESCRIPTION
This pull request updates the filebeats and journalbeats docker build to use Go 1.14.4 instead of Go 1.13.3.  With Go 1.13.3, filebeats was continuously logging  **_http2: no cached connection was available_** and eventually pods were being evicted due to ephemeral storage being depleted. The previous Sauron image we were using was using Go 1.14 and did not have this problem with logging and pod eviction.